### PR TITLE
Upgrade php to php7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vsense/nginx:php-fpm
+FROM vsense/nginx:php7-fpm
 
 MAINTAINER vSense <docker@vsense.fr>
 
@@ -6,10 +6,12 @@ ENV PKGVER 0.28.1
 
 RUN apk add --update  \
     ffmpeg \
-    php-gd \
-    php-exif \
-    php-json \
-    imagemagick \
+    libwebp@edge \
+    php7-gd@testing \
+    php7-exif@testing \
+    php7-json@testing \
+    php7-session@testing \
+    imagemagick@edge \
     zip \
     wget \
     && wget --no-check-certificate https://release.larsjung.de/h5ai/h5ai-"$PKGVER".zip -P /tmp \


### PR DESCRIPTION
So... I've changed Dockerbuild to use php7... I'm using php7 with h5ai for a 3-4 weeks right now and I didn't notice any problems with that, besides it's much more fasteeer (and of course it's consuming much less memory) !  💯  
